### PR TITLE
Update web3 dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[cljs-web3 "0.19.0-0-10"]
+  :dependencies [[io.github.district0x/cljs-web3-next "0.2.0-SNAPSHOT"]
+                 [io.github.district0x/district-ui-web3 "1.3.3-SNAPSHOT"]
                  [day8.re-frame/forward-events-fx "0.0.6"]
-                 [district0x/district-ui-web3 "1.3.2"]
                  [district0x/district-ui-window-focus "1.0.0"]
                  [district0x/eip55 "0.0.1"]
                  [district0x/re-frame-interval-fx "1.0.2"]
@@ -14,11 +14,11 @@
                  [district0x.re-frame/web3-fx "1.0.5"]
                  [mount "0.1.16"]
                  [org.clojure/clojurescript "1.10.597"]
-                 [re-frame "0.11.0"]]
+                 [re-frame "1.2.0"]]
 
   :doo {:paths {:karma "./node_modules/karma/bin/karma"}}
 
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.1"]
                                   [day8.re-frame/test "0.1.5"]]
                    :source-paths ["src" "test"]
                    :plugins [[lein-cljsbuild "1.1.7"]

--- a/src/district/ui/web3_accounts/events.cljs
+++ b/src/district/ui/web3_accounts/events.cljs
@@ -1,6 +1,6 @@
 (ns district.ui.web3-accounts.events
-  (:require [cljs-web3.core :as web3]
-            [cljs-web3.eth :as web3-eth]
+  (:require [cljs-web3-next.core :as web3]
+            [cljs-web3-next.eth :as web3-eth]
             [cljs.spec.alpha :as s]
             [day8.re-frame.forward-events-fx]
             [district.ui.web3-accounts.effects :as effects]


### PR DESCRIPTION
Because some core libraries (cljs-web3-next) moved to Web3.js 1.7,
this one needs its dependencies bumped as well